### PR TITLE
Typo fix for cron job

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ bg: true
 dyn: true
 ---
 <p class="bigger">The table shows statistics and a ranking of the <strong>10k</strong> most popular JavaScript projects on GitHub. The normalized values are calculated by the given number of <strong>stars and forks</strong> of a project.</p>
-   <p>This page was <strong>generated <span id="gen">{{ site.time }}</span></strong> and will be recreated by a chronjob three times a day with the most recent data (also available for download as <a href="10kJS.json" title="10kJS.json" rel="nofollow" target="_blank">JSON</a> or <a href="10kJS.csv" title="10kJS.csv" rel="nofollow" target="_blank">CSV</a>).<br>You can use the column headers to sort the table and toggle the display of changes in the ranking for a particular timeframe. And if you are looking for a certain project you can just use the search form.</p>
+   <p>This page was <strong>generated <span id="gen">{{ site.time }}</span></strong> and will be recreated by a cron job three times a day with the most recent data (also available for download as <a href="10kJS.json" title="10kJS.json" rel="nofollow" target="_blank">JSON</a> or <a href="10kJS.csv" title="10kJS.csv" rel="nofollow" target="_blank">CSV</a>).<br>You can use the column headers to sort the table and toggle the display of changes in the ranking for a particular timeframe. And if you are looking for a certain project you can just use the search form.</p>
    <p><strong>Important:</strong> This is not a usage-statistic and does not necessarily reflect what you will find in the wild!</p>
    <input id="iP" class="switch btf" type="radio" name="delta" />
    <input id="iD" class="switch btf" type="radio" name="delta" />


### PR DESCRIPTION
Small typo fix on homepage.

`chronjob` -> `cron job`
